### PR TITLE
Fix/connection leak and reconnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ env/
 venv/
 build/
 src/amqpstorm_flask.egg-info
-.venv/
+.venv/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 env/
 .idea/
 venv/
-tests/
 build/
 src/amqpstorm_flask.egg-info
+.venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "amqpstorm-flask"
-version = "0.5.4"
+version = "0.6.0-dev"
 description = "amqpstorm library for Flask"
 readme = "README.md"
 authors = [{ name = "Inuits", email = "developers@inuits.eu" }]

--- a/src/amqpstorm_flask/RabbitMQ.py
+++ b/src/amqpstorm_flask/RabbitMQ.py
@@ -55,6 +55,8 @@ class RabbitMQ:
         self.last_message_consumed_at = 0
         self.scheduler = BackgroundScheduler()
         self._reconnect_lock = threading.Lock()
+        self._publish_lock = threading.Lock()
+        self._consumer_channels = []
 
     def init_app(
             self,
@@ -100,24 +102,39 @@ class RabbitMQ:
                 self._validate_channel_connection()
 
     def check_health(self, check_consumers=True):
-        if not self.get_connection().is_open:
+        if not self.connection or not self.connection.is_open:
             return False, "Connection not open"
-        if check_consumers and len(self.channel.consumer_tags) < 1:
-            return False, "No consumers available"
+        if check_consumers:
+            active = [ch for ch in self._consumer_channels
+                      if ch and not ch.is_closed and ch.consumer_tags]
+            if not active:
+                return False, "No consumers available"
         return True, "Connection open"
 
     def get_connection(self):
         return self.connection
 
     def _close_connection(self):
-        """Safely close the existing connection and channel."""
+        """Safely close the existing connection and all channels."""
+        for ch in self._consumer_channels:
+            try:
+                if ch and not ch.is_closed:
+                    ch.close()
+            except Exception:
+                pass
+        self._consumer_channels.clear()
+        try:
+            if self.channel and not self.channel.is_closed:
+                self.channel.close()
+        except Exception:
+            pass
+        self.channel = None
         try:
             if self.connection and not self.connection.is_closed:
                 self.connection.close()
         except Exception:
             pass
         self.connection = None
-        self.channel = None
 
     def _validate_channel_connection(self):
         if not self._reconnect_lock.acquire(blocking=False):
@@ -128,8 +145,6 @@ class RabbitMQ:
             needs_reconnect = (
                 not self.connection
                 or self.connection.is_closed
-                or self.channel is None
-                or self.channel.is_closed
                 or self.last_message_consumed_at == -1
                 or (self.last_message_consumed_at != 0
                     and consumed_seconds_ago > max_consumer_idle_time)
@@ -143,6 +158,13 @@ class RabbitMQ:
                 except Exception as ex:
                     self.logger.error(
                         f"An error occurred while renewing rabbit connection: {str(ex)}"
+                    )
+            elif self.channel is None or self.channel.is_closed:
+                try:
+                    self.channel = self.connection.channel()
+                except Exception as ex:
+                    self.logger.error(
+                        f"An error occurred while renewing rabbit channel: {str(ex)}"
                     )
         finally:
             self._reconnect_lock.release()
@@ -163,24 +185,25 @@ class RabbitMQ:
         exchange = (
             f"{exchange_name}-development" if self.development else exchange_name
         )
-        self._validate_channel_connection()
-        self.channel.exchange.declare(
-            exchange=f"{exchange}-debug" if debug_exchange else exchange,
-            exchange_type=exchange_type,
-            passive=self.exchange_params.passive,
-            durable=self.exchange_params.durable,
-            auto_delete=self.exchange_params.auto_delete,
-        )
+        with self._publish_lock:
+            self._validate_channel_connection()
+            self.channel.exchange.declare(
+                exchange=f"{exchange}-debug" if debug_exchange else exchange,
+                exchange_type=exchange_type,
+                passive=self.exchange_params.passive,
+                durable=self.exchange_params.durable,
+                auto_delete=self.exchange_params.auto_delete,
+            )
 
-        retry_call(
-            self._publish_to_channel,
-            (body, routing_key, message_version, debug_exchange, exchange_name),
-            properties,
-            exceptions=(AMQPConnectionError, AssertionError),
-            tries=retries,
-            delay=5,
-            jitter=(5, 15),
-        )
+            retry_call(
+                self._publish_to_channel,
+                (body, routing_key, message_version, debug_exchange, exchange_name),
+                properties,
+                exceptions=(AMQPConnectionError, AssertionError),
+                tries=retries,
+                delay=5,
+                jitter=(5, 15),
+            )
 
     def _publish_to_channel(
             self,
@@ -250,40 +273,47 @@ class RabbitMQ:
                     backoff = 1
                     max_backoff = 60
                     while True:
+                        consumer_channel = None
                         try:
                             self._validate_channel_connection()
-                            self.channel.exchange.declare(
+                            if not self.connection or self.connection.is_closed:
+                                raise AMQPConnectionError("No connection available")
+                            consumer_channel = self.connection.channel()
+                            self._consumer_channels.append(consumer_channel)
+                            consumer_channel.exchange.declare(
                                 exchange=exchange_name if exchange_name else self.mq_exchange,
                                 exchange_type=exchange_type,
                                 durable=self.exchange_params.durable,
                                 passive=self.exchange_params.passive,
                                 auto_delete=self.exchange_params.auto_delete,
                             )
-                            self.channel.queue.declare(
+                            consumer_channel.queue.declare(
                                 queue=queue,
                                 durable=self.queue_params.durable,
                                 passive=self.queue_params.passive if passive_queue is None else passive_queue,
                                 auto_delete=self.queue_params.auto_delete,
                                 arguments=queue_arguments,
                             )
-                            self.channel.basic.qos(prefetch_count=prefetch_count)
+                            consumer_channel.basic.qos(prefetch_count=prefetch_count)
                             cb_function = f if full_message_object else self.__create_wrapper_function(routing_key, f)
-                            self.channel.basic.consume(
+                            consumer_channel.basic.consume(
                                 cb_function, queue=queue,
                                 no_ack=self.queue_params.no_ack if auto_ack is None else auto_ack
                             )
 
                             keys = [routing_key] if isinstance(routing_key, str) else routing_key
                             for key in keys:
-                                self.channel.queue.bind(
+                                consumer_channel.queue.bind(
                                     queue=queue,
                                     exchange=exchange_name if exchange_name else self.mq_exchange,
                                     routing_key=key,
                                 )
                             self.logger.info(f"Start consuming queue {queue}")
                             backoff = 1
-                            self.channel.start_consuming()
+                            consumer_channel.start_consuming()
                         except Exception as ex:
+                            if consumer_channel in self._consumer_channels:
+                                self._consumer_channels.remove(consumer_channel)
                             if int(getenv("AMQP_STORM_APSCHEDULER", 1)) == 1:
                                 self.logger.error(
                                     f"An error occurred while consuming queue {queue}: {str(ex)}, apscheduler will try to restart it every 5 seconds"

--- a/src/amqpstorm_flask/RabbitMQ.py
+++ b/src/amqpstorm_flask/RabbitMQ.py
@@ -13,7 +13,6 @@ from hashlib import sha256
 from retry.api import retry_call
 from time import sleep, time
 from typing import Union, List
-from warnings import filterwarnings
 from apscheduler.schedulers.background import BackgroundScheduler
 
 
@@ -56,7 +55,9 @@ class RabbitMQ:
         self.scheduler = BackgroundScheduler()
         self._reconnect_lock = threading.Lock()
         self._publish_lock = threading.Lock()
+        self._consumer_channels_lock = threading.Lock()
         self._consumer_channels = []
+        self._exchange_declared = set()
 
     def init_app(
             self,
@@ -105,8 +106,12 @@ class RabbitMQ:
         if not self.connection or not self.connection.is_open:
             return False, "Connection not open"
         if check_consumers:
-            active = [ch for ch in self._consumer_channels
-                      if ch and not ch.is_closed and ch.consumer_tags]
+            with self._consumer_channels_lock:
+                self._consumer_channels = [
+                    ch for ch in self._consumer_channels
+                    if ch and not ch.is_closed
+                ]
+                active = [ch for ch in self._consumer_channels if ch.consumer_tags]
             if not active:
                 return False, "No consumers available"
         return True, "Connection open"
@@ -116,13 +121,14 @@ class RabbitMQ:
 
     def _close_connection(self):
         """Safely close the existing connection and all channels."""
-        for ch in self._consumer_channels:
-            try:
-                if ch and not ch.is_closed:
-                    ch.close()
-            except Exception:
-                pass
-        self._consumer_channels.clear()
+        with self._consumer_channels_lock:
+            for ch in self._consumer_channels:
+                try:
+                    if ch and not ch.is_closed:
+                        ch.close()
+                except Exception:
+                    pass
+            self._consumer_channels.clear()
         try:
             if self.channel and not self.channel.is_closed:
                 self.channel.close()
@@ -135,6 +141,7 @@ class RabbitMQ:
         except Exception:
             pass
         self.connection = None
+        self._exchange_declared.clear()
 
     def _validate_channel_connection(self):
         if not self._reconnect_lock.acquire(blocking=False):
@@ -169,6 +176,18 @@ class RabbitMQ:
         finally:
             self._reconnect_lock.release()
 
+    def _declare_exchange(self, channel, exchange, exchange_type):
+        """Declare exchange on channel, skipping if already declared on this connection."""
+        if exchange not in self._exchange_declared:
+            channel.exchange.declare(
+                exchange=exchange,
+                exchange_type=exchange_type,
+                passive=self.exchange_params.passive,
+                durable=self.exchange_params.durable,
+                auto_delete=self.exchange_params.auto_delete,
+            )
+            self._exchange_declared.add(exchange)
+
     def send(
             self,
             body,
@@ -180,21 +199,14 @@ class RabbitMQ:
             exchange_name: str = None,
             **properties,
     ):
-        filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
         exchange_name = self.mq_exchange if exchange_name is None else exchange_name
         exchange = (
             f"{exchange_name}-development" if self.development else exchange_name
         )
+        resolved_exchange = f"{exchange}-debug" if debug_exchange else exchange
         with self._publish_lock:
             self._validate_channel_connection()
-            self.channel.exchange.declare(
-                exchange=f"{exchange}-debug" if debug_exchange else exchange,
-                exchange_type=exchange_type,
-                passive=self.exchange_params.passive,
-                durable=self.exchange_params.durable,
-                auto_delete=self.exchange_params.auto_delete,
-            )
-
+            self._declare_exchange(self.channel, resolved_exchange, exchange_type)
             retry_call(
                 self._publish_to_channel,
                 (body, routing_key, message_version, debug_exchange, exchange_name),
@@ -223,7 +235,6 @@ class RabbitMQ:
         if "headers" not in properties:
             properties["headers"] = {}
         properties["headers"]["x-message-version"] = message_version
-        filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
         self._validate_channel_connection()
         self.channel.basic.publish(
             exchange=f"{exchange_name}-debug" if debug_exchange is True else exchange_name,
@@ -271,7 +282,7 @@ class RabbitMQ:
                 @wraps(f)
                 def new_consumer():
                     backoff = 1
-                    max_backoff = 60
+                    max_backoff = int(getenv("MQ_MAX_CONSUMER_BACKOFF", 60))
                     while True:
                         consumer_channel = None
                         try:
@@ -279,7 +290,8 @@ class RabbitMQ:
                             if not self.connection or self.connection.is_closed:
                                 raise AMQPConnectionError("No connection available")
                             consumer_channel = self.connection.channel()
-                            self._consumer_channels.append(consumer_channel)
+                            with self._consumer_channels_lock:
+                                self._consumer_channels.append(consumer_channel)
                             consumer_channel.exchange.declare(
                                 exchange=exchange_name if exchange_name else self.mq_exchange,
                                 exchange_type=exchange_type,
@@ -312,8 +324,9 @@ class RabbitMQ:
                             backoff = 1
                             consumer_channel.start_consuming()
                         except Exception as ex:
-                            if consumer_channel in self._consumer_channels:
-                                self._consumer_channels.remove(consumer_channel)
+                            with self._consumer_channels_lock:
+                                if consumer_channel in self._consumer_channels:
+                                    self._consumer_channels.remove(consumer_channel)
                             if int(getenv("AMQP_STORM_APSCHEDULER", 1)) == 1:
                                 self.logger.error(
                                     f"An error occurred while consuming queue {queue}: {str(ex)}, apscheduler will try to restart it every 5 seconds"
@@ -342,4 +355,11 @@ class RabbitMQ:
 
     def stop(self):
         self.scheduler.shutdown()
+        with self._consumer_channels_lock:
+            for ch in self._consumer_channels:
+                try:
+                    if ch and not ch.is_closed:
+                        ch.stop_consuming()
+                except Exception:
+                    pass
         self._close_connection()

--- a/src/amqpstorm_flask/RabbitMQ.py
+++ b/src/amqpstorm_flask/RabbitMQ.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import sys
 import threading
 from os import getenv
 
@@ -55,6 +54,7 @@ class RabbitMQ:
         self.development = development if development is not None else False
         self.last_message_consumed_at = 0
         self.scheduler = BackgroundScheduler()
+        self._reconnect_lock = threading.Lock()
 
     def init_app(
             self,
@@ -109,22 +109,43 @@ class RabbitMQ:
     def get_connection(self):
         return self.connection
 
+    def _close_connection(self):
+        """Safely close the existing connection and channel."""
+        try:
+            if self.connection and not self.connection.is_closed:
+                self.connection.close()
+        except Exception:
+            pass
+        self.connection = None
+        self.channel = None
+
     def _validate_channel_connection(self):
-        max_consumer_idle_time = int(getenv("MQ_MAX_CONSUMER_IDLE_TIME", 300))
-        consumed_seconds_ago = (time() - self.last_message_consumed_at)
-        if (not self.connection or self.get_connection().is_closed or self.channel.is_closed or
-                self.last_message_consumed_at == -1 or (self.last_message_consumed_at != 0 and (consumed_seconds_ago > max_consumer_idle_time))):
-            try:
-                self.connection = UriConnection(self.mq_url)
-                self.channel = self.get_connection().channel()
-                self.last_message_consumed_at = 0
-            except BaseException as ex:
-                if int(getenv("AMQP_STORM_APSCHEDULER", 1)) == 0:
-                    sleep(1)
-                    self._validate_channel_connection()
-                self.logger.error(
-                    f"An error occurred while renewing rabbit connection: {str(ex)}"
-                )
+        if not self._reconnect_lock.acquire(blocking=False):
+            return
+        try:
+            max_consumer_idle_time = int(getenv("MQ_MAX_CONSUMER_IDLE_TIME", 300))
+            consumed_seconds_ago = (time() - self.last_message_consumed_at)
+            needs_reconnect = (
+                not self.connection
+                or self.connection.is_closed
+                or self.channel is None
+                or self.channel.is_closed
+                or self.last_message_consumed_at == -1
+                or (self.last_message_consumed_at != 0
+                    and consumed_seconds_ago > max_consumer_idle_time)
+            )
+            if needs_reconnect:
+                try:
+                    self._close_connection()
+                    self.connection = UriConnection(self.mq_url)
+                    self.channel = self.connection.channel()
+                    self.last_message_consumed_at = 0
+                except Exception as ex:
+                    self.logger.error(
+                        f"An error occurred while renewing rabbit connection: {str(ex)}"
+                    )
+        finally:
+            self._reconnect_lock.release()
 
     def send(
             self,
@@ -226,49 +247,54 @@ class RabbitMQ:
             if enabled_queues is None or queue in enabled_queues:
                 @wraps(f)
                 def new_consumer():
-                    try:
-                        self._validate_channel_connection()
-                        self.channel.exchange.declare(
-                            exchange=exchange_name if exchange_name else self.mq_exchange,
-                            exchange_type=exchange_type,
-                            durable=self.exchange_params.durable,
-                            passive=self.exchange_params.passive,
-                            auto_delete=self.exchange_params.auto_delete,
-                        )
-                        self.channel.queue.declare(
-                            queue=queue,
-                            durable=self.queue_params.durable,
-                            passive=self.queue_params.passive if passive_queue is None else passive_queue,
-                            auto_delete=self.queue_params.auto_delete,
-                            arguments=queue_arguments,
-                        )
-                        self.channel.basic.qos(prefetch_count=prefetch_count)
-                        cb_function = f if full_message_object else self.__create_wrapper_function(routing_key, f)
-                        self.channel.basic.consume(
-                            cb_function, queue=queue,
-                            no_ack=self.queue_params.no_ack if auto_ack is None else auto_ack
-                        )
-
-                        keys = [routing_key] if isinstance(routing_key, str) else routing_key
-                        for key in keys:
-                            self.channel.queue.bind(
-                                queue=queue,
+                    backoff = 1
+                    max_backoff = 60
+                    while True:
+                        try:
+                            self._validate_channel_connection()
+                            self.channel.exchange.declare(
                                 exchange=exchange_name if exchange_name else self.mq_exchange,
-                                routing_key=key,
+                                exchange_type=exchange_type,
+                                durable=self.exchange_params.durable,
+                                passive=self.exchange_params.passive,
+                                auto_delete=self.exchange_params.auto_delete,
                             )
-                        self.logger.info(f"Start consuming queue {queue}")
-                        self.channel.start_consuming()
-                    except BaseException as ex:
-                        if int(getenv("AMQP_STORM_APSCHEDULER", 1)) == 1:
-                            self.logger.error(
-                                f"An error occurred while consuming queue {queue}: {str(ex)}, apscheduler will try to restart it every 5 seconds"
+                            self.channel.queue.declare(
+                                queue=queue,
+                                durable=self.queue_params.durable,
+                                passive=self.queue_params.passive if passive_queue is None else passive_queue,
+                                auto_delete=self.queue_params.auto_delete,
+                                arguments=queue_arguments,
                             )
-                        else:
-                            self.logger.error(
-                                f"An error occurred while consuming queue {queue}: {str(ex)}, restarting consumer"
+                            self.channel.basic.qos(prefetch_count=prefetch_count)
+                            cb_function = f if full_message_object else self.__create_wrapper_function(routing_key, f)
+                            self.channel.basic.consume(
+                                cb_function, queue=queue,
+                                no_ack=self.queue_params.no_ack if auto_ack is None else auto_ack
                             )
-                            sleep(1)
-                            new_consumer()
+
+                            keys = [routing_key] if isinstance(routing_key, str) else routing_key
+                            for key in keys:
+                                self.channel.queue.bind(
+                                    queue=queue,
+                                    exchange=exchange_name if exchange_name else self.mq_exchange,
+                                    routing_key=key,
+                                )
+                            self.logger.info(f"Start consuming queue {queue}")
+                            backoff = 1
+                            self.channel.start_consuming()
+                        except Exception as ex:
+                            if int(getenv("AMQP_STORM_APSCHEDULER", 1)) == 1:
+                                self.logger.error(
+                                    f"An error occurred while consuming queue {queue}: {str(ex)}, apscheduler will try to restart it every 5 seconds"
+                                )
+                                return
+                            else:
+                                self.logger.error(
+                                    f"An error occurred while consuming queue {queue}: {str(ex)}, restarting consumer in {backoff}s"
+                                )
+                                sleep(backoff)
+                                backoff = min(backoff * 2, max_backoff)
 
                 if int(getenv("AMQP_STORM_APSCHEDULER", 1)) == 1:
                     self.scheduler.add_job(new_consumer, "interval", seconds=5, max_instances=1, name=f"amqp_consumer_job_{f.__name__}")
@@ -286,3 +312,4 @@ class RabbitMQ:
 
     def stop(self):
         self.scheduler.shutdown()
+        self._close_connection()

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,30 +1,44 @@
 import threading
 import time
 from unittest import TestCase
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch, call
+
+
+def _make_rabbit():
+    with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
+        from amqpstorm_flask.RabbitMQ import RabbitMQ
+        rabbit = RabbitMQ.__new__(RabbitMQ)
+        rabbit.connection = None
+        rabbit.channel = None
+        rabbit.mq_url = "amqp://localhost"
+        rabbit.mq_exchange = "test"
+        rabbit.logger = MagicMock()
+        rabbit.last_message_consumed_at = 0
+        rabbit._reconnect_lock = threading.Lock()
+        rabbit._publish_lock = threading.Lock()
+        rabbit._consumer_channels = []
+        rabbit.scheduler = MagicMock()
+        rabbit.exchange_params = MagicMock()
+        rabbit.queue_params = MagicMock()
+    return rabbit
+
+
+def _make_mock_connection(with_channel=True):
+    conn = MagicMock()
+    conn.is_closed = False
+    conn.is_open = True
+    if with_channel:
+        channel = MagicMock()
+        channel.is_closed = False
+        channel.consumer_tags = []
+        conn.channel.return_value = channel
+    return conn
 
 
 class TestCloseConnection(TestCase):
-    def _make_rabbit(self):
-        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
-            from amqpstorm_flask.RabbitMQ import RabbitMQ
-            rabbit = RabbitMQ.__new__(RabbitMQ)
-            rabbit.connection = None
-            rabbit.channel = None
-            rabbit.mq_url = "amqp://localhost"
-            rabbit.mq_exchange = "test"
-            rabbit.logger = MagicMock()
-            rabbit.last_message_consumed_at = 0
-            rabbit._reconnect_lock = threading.Lock()
-            rabbit.scheduler = MagicMock()
-            rabbit.exchange_params = MagicMock()
-            rabbit.queue_params = MagicMock()
-        return rabbit
-
     def test_close_connection_when_open(self):
-        rabbit = self._make_rabbit()
-        mock_conn = MagicMock()
-        mock_conn.is_closed = False
+        rabbit = _make_rabbit()
+        mock_conn = _make_mock_connection()
         rabbit.connection = mock_conn
 
         rabbit._close_connection()
@@ -34,7 +48,7 @@ class TestCloseConnection(TestCase):
         self.assertIsNone(rabbit.channel)
 
     def test_close_connection_when_already_closed(self):
-        rabbit = self._make_rabbit()
+        rabbit = _make_rabbit()
         mock_conn = MagicMock()
         mock_conn.is_closed = True
         rabbit.connection = mock_conn
@@ -45,8 +59,7 @@ class TestCloseConnection(TestCase):
         self.assertIsNone(rabbit.connection)
 
     def test_close_connection_when_none(self):
-        rabbit = self._make_rabbit()
-        rabbit.connection = None
+        rabbit = _make_rabbit()
 
         rabbit._close_connection()
 
@@ -54,7 +67,7 @@ class TestCloseConnection(TestCase):
         self.assertIsNone(rabbit.channel)
 
     def test_close_connection_handles_close_exception(self):
-        rabbit = self._make_rabbit()
+        rabbit = _make_rabbit()
         mock_conn = MagicMock()
         mock_conn.is_closed = False
         mock_conn.close.side_effect = Exception("socket error")
@@ -65,106 +78,99 @@ class TestCloseConnection(TestCase):
         self.assertIsNone(rabbit.connection)
         self.assertIsNone(rabbit.channel)
 
+    def test_close_connection_closes_consumer_channels(self):
+        rabbit = _make_rabbit()
+        ch1 = MagicMock(is_closed=False)
+        ch2 = MagicMock(is_closed=False)
+        rabbit._consumer_channels = [ch1, ch2]
+        rabbit.connection = _make_mock_connection()
+
+        rabbit._close_connection()
+
+        ch1.close.assert_called_once()
+        ch2.close.assert_called_once()
+        self.assertEqual(rabbit._consumer_channels, [])
+
+    def test_close_connection_ignores_failed_channel_close(self):
+        rabbit = _make_rabbit()
+        ch1 = MagicMock(is_closed=False)
+        ch1.close.side_effect = Exception("already closed")
+        rabbit._consumer_channels = [ch1]
+        rabbit.connection = _make_mock_connection()
+
+        rabbit._close_connection()
+
+        self.assertEqual(rabbit._consumer_channels, [])
+        self.assertIsNone(rabbit.connection)
+
 
 class TestValidateChannelConnection(TestCase):
-    def _make_rabbit(self):
-        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
-            from amqpstorm_flask.RabbitMQ import RabbitMQ
-            rabbit = RabbitMQ.__new__(RabbitMQ)
-            rabbit.connection = None
-            rabbit.channel = None
-            rabbit.mq_url = "amqp://localhost"
-            rabbit.mq_exchange = "test"
-            rabbit.logger = MagicMock()
-            rabbit.last_message_consumed_at = 0
-            rabbit._reconnect_lock = threading.Lock()
-            rabbit.scheduler = MagicMock()
-            rabbit.exchange_params = MagicMock()
-            rabbit.queue_params = MagicMock()
-        return rabbit
-
     @patch("amqpstorm_flask.RabbitMQ.UriConnection")
     def test_validate_handles_none_channel(self, mock_uri_conn):
-        rabbit = self._make_rabbit()
-        rabbit.connection = None
-        rabbit.channel = None
-
-        mock_conn = MagicMock()
-        mock_conn.is_closed = False
-        mock_channel = MagicMock()
-        mock_channel.is_closed = False
-        mock_conn.channel.return_value = mock_channel
+        rabbit = _make_rabbit()
+        mock_conn = _make_mock_connection()
         mock_uri_conn.return_value = mock_conn
 
         rabbit._validate_channel_connection()
 
         mock_uri_conn.assert_called_once_with("amqp://localhost")
         self.assertEqual(rabbit.connection, mock_conn)
-        self.assertEqual(rabbit.channel, mock_channel)
+        self.assertIsNotNone(rabbit.channel)
 
     @patch("amqpstorm_flask.RabbitMQ.UriConnection")
     def test_validate_closes_old_connection(self, mock_uri_conn):
-        rabbit = self._make_rabbit()
-
-        old_conn = MagicMock()
-        old_conn.is_closed = False
+        rabbit = _make_rabbit()
+        old_conn = _make_mock_connection()
         rabbit.connection = old_conn
-        rabbit.channel = MagicMock()
-        rabbit.channel.is_closed = False
-
+        rabbit.channel = MagicMock(is_closed=False)
         rabbit.last_message_consumed_at = -1
 
-        new_conn = MagicMock()
-        new_conn.is_closed = False
-        new_channel = MagicMock()
-        new_channel.is_closed = False
-        new_conn.channel.return_value = new_channel
+        new_conn = _make_mock_connection()
         mock_uri_conn.return_value = new_conn
 
         rabbit._validate_channel_connection()
 
         old_conn.close.assert_called_once()
         self.assertEqual(rabbit.connection, new_conn)
-        self.assertEqual(rabbit.channel, new_channel)
 
     @patch("amqpstorm_flask.RabbitMQ.UriConnection")
     def test_validate_skips_when_healthy(self, mock_uri_conn):
-        rabbit = self._make_rabbit()
-
-        mock_conn = MagicMock()
-        mock_conn.is_closed = False
-        mock_channel = MagicMock()
-        mock_channel.is_closed = False
-        rabbit.connection = mock_conn
-        rabbit.channel = mock_channel
-        rabbit.last_message_consumed_at = 0
+        rabbit = _make_rabbit()
+        rabbit.connection = _make_mock_connection()
+        rabbit.channel = MagicMock(is_closed=False)
 
         rabbit._validate_channel_connection()
 
         mock_uri_conn.assert_not_called()
 
     @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_validate_recreates_dead_publish_channel(self, mock_uri_conn):
+        rabbit = _make_rabbit()
+        conn = _make_mock_connection()
+        rabbit.connection = conn
+        rabbit.channel = MagicMock(is_closed=True)
+
+        new_channel = MagicMock(is_closed=False)
+        conn.channel.return_value = new_channel
+
+        rabbit._validate_channel_connection()
+
+        mock_uri_conn.assert_not_called()
+        self.assertEqual(rabbit.channel, new_channel)
+
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
     def test_validate_lock_prevents_concurrent_reconnection(self, mock_uri_conn):
-        rabbit = self._make_rabbit()
-        rabbit.connection = None
-        rabbit.channel = None
+        rabbit = _make_rabbit()
 
         call_count = 0
         barrier = threading.Barrier(2, timeout=5)
-
-        original_uri = mock_uri_conn
 
         def slow_connect(url):
             nonlocal call_count
             call_count += 1
             barrier.wait()
             time.sleep(0.1)
-            conn = MagicMock()
-            conn.is_closed = False
-            channel = MagicMock()
-            channel.is_closed = False
-            conn.channel.return_value = channel
-            return conn
+            return _make_mock_connection()
 
         mock_uri_conn.side_effect = slow_connect
 
@@ -179,16 +185,83 @@ class TestValidateChannelConnection(TestCase):
 
     @patch("amqpstorm_flask.RabbitMQ.UriConnection")
     def test_validate_logs_error_on_connection_failure(self, mock_uri_conn):
-        rabbit = self._make_rabbit()
-        rabbit.connection = None
-        rabbit.channel = None
-
+        rabbit = _make_rabbit()
         mock_uri_conn.side_effect = Exception("Connection refused")
 
         rabbit._validate_channel_connection()
 
         rabbit.logger.error.assert_called_once()
         self.assertIn("Connection refused", rabbit.logger.error.call_args[0][0])
+
+
+class TestPerConsumerChannels(TestCase):
+    @patch("amqpstorm_flask.RabbitMQ.sleep")
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    @patch.dict("os.environ", {
+        "AMQP_STORM_APSCHEDULER": "0",
+        "WERKZEUG_RUN_MAIN": "true",
+        "MQ_URL": "amqp://localhost",
+        "MQ_EXCHANGE": "test",
+    })
+    def test_each_consumer_gets_own_channel(self, mock_uri_conn, mock_sleep):
+        from amqpstorm_flask.RabbitMQ import RabbitMQ
+
+        channels_created = []
+        done_event = threading.Event()
+        conn = _make_mock_connection(with_channel=False)
+
+        def make_channel():
+            ch = MagicMock()
+            ch.is_closed = False
+            ch.consumer_tags = ["tag"]
+            channels_created.append(ch)
+            if len(channels_created) >= 3:
+                ch.start_consuming.side_effect = lambda: done_event.set() or time.sleep(5)
+            else:
+                ch.start_consuming.side_effect = lambda: done_event.set() or time.sleep(5)
+            return ch
+
+        conn.channel.side_effect = make_channel
+        mock_uri_conn.return_value = conn
+
+        rabbit = RabbitMQ.__new__(RabbitMQ)
+        rabbit.connection = None
+        rabbit.channel = None
+        rabbit.mq_url = "amqp://localhost"
+        rabbit.mq_exchange = "test"
+        rabbit.logger = MagicMock()
+        rabbit.last_message_consumed_at = 0
+        rabbit._reconnect_lock = threading.Lock()
+        rabbit._publish_lock = threading.Lock()
+        rabbit._consumer_channels = []
+        rabbit.scheduler = MagicMock()
+        rabbit.exchange_params = MagicMock()
+        rabbit.queue_params = MagicMock()
+        rabbit.queue_params.no_ack = True
+        rabbit.queue_params.durable = True
+        rabbit.queue_params.passive = False
+        rabbit.queue_params.auto_delete = False
+        rabbit.json_encoder = None
+        rabbit.development = False
+
+        @rabbit.queue(routing_key="test.key1", queue_name="queue-1")
+        def handler_one(routing_key, body, message_id):
+            pass
+
+        @rabbit.queue(routing_key="test.key2", queue_name="queue-2")
+        def handler_two(routing_key, body, message_id):
+            pass
+
+        done_event.wait(timeout=10)
+
+        # 1 publish channel (from _validate_channel_connection) + 2 consumer channels
+        self.assertGreaterEqual(len(channels_created), 3)
+        # Consumer channels should be different from each other
+        consumer_chs = rabbit._consumer_channels
+        self.assertEqual(len(consumer_chs), 2)
+        self.assertIsNot(consumer_chs[0], consumer_chs[1])
+        # Publish channel (self.channel) should be separate from consumer channels
+        self.assertNotIn(rabbit.channel, consumer_chs)
 
 
 class TestNewConsumerNoRecursion(TestCase):
@@ -212,16 +285,20 @@ class TestNewConsumerNoRecursion(TestCase):
             attempt += 1
             if attempt <= max_failures:
                 raise Exception(f"Failure {attempt}")
-            conn = MagicMock()
-            conn.is_closed = False
-            channel = MagicMock()
-            channel.is_closed = False
+            conn = _make_mock_connection(with_channel=False)
 
-            def stop_consuming():
-                done_event.set()
-                raise Exception("done")
-            channel.start_consuming.side_effect = stop_consuming
-            conn.channel.return_value = channel
+            def make_channel():
+                ch = MagicMock()
+                ch.is_closed = False
+                ch.consumer_tags = []
+
+                def stop_consuming():
+                    done_event.set()
+                    raise Exception("done")
+                ch.start_consuming.side_effect = stop_consuming
+                return ch
+
+            conn.channel.side_effect = make_channel
             return conn
 
         mock_uri_conn.side_effect = side_effect
@@ -234,6 +311,8 @@ class TestNewConsumerNoRecursion(TestCase):
         rabbit.logger = MagicMock()
         rabbit.last_message_consumed_at = 0
         rabbit._reconnect_lock = threading.Lock()
+        rabbit._publish_lock = threading.Lock()
+        rabbit._consumer_channels = []
         rabbit.scheduler = MagicMock()
         rabbit.exchange_params = MagicMock()
         rabbit.queue_params = MagicMock()
@@ -253,34 +332,100 @@ class TestNewConsumerNoRecursion(TestCase):
         self.assertGreater(attempt, max_failures)
 
 
+class TestCheckHealth(TestCase):
+    def test_health_ok_with_active_consumers(self):
+        rabbit = _make_rabbit()
+        rabbit.connection = _make_mock_connection()
+        ch = MagicMock(is_closed=False, consumer_tags=["consumer-1"])
+        rabbit._consumer_channels = [ch]
+
+        ok, msg = rabbit.check_health()
+
+        self.assertTrue(ok)
+        self.assertEqual(msg, "Connection open")
+
+    def test_health_fails_no_connection(self):
+        rabbit = _make_rabbit()
+        rabbit.connection = None
+
+        ok, msg = rabbit.check_health()
+
+        self.assertFalse(ok)
+        self.assertEqual(msg, "Connection not open")
+
+    def test_health_fails_no_consumers(self):
+        rabbit = _make_rabbit()
+        rabbit.connection = _make_mock_connection()
+        rabbit._consumer_channels = []
+
+        ok, msg = rabbit.check_health(check_consumers=True)
+
+        self.assertFalse(ok)
+        self.assertEqual(msg, "No consumers available")
+
+    def test_health_ok_without_consumer_check(self):
+        rabbit = _make_rabbit()
+        rabbit.connection = _make_mock_connection()
+        rabbit._consumer_channels = []
+
+        ok, msg = rabbit.check_health(check_consumers=False)
+
+        self.assertTrue(ok)
+
+    def test_health_ignores_dead_consumer_channels(self):
+        rabbit = _make_rabbit()
+        rabbit.connection = _make_mock_connection()
+        dead_ch = MagicMock(is_closed=True, consumer_tags=["old"])
+        rabbit._consumer_channels = [dead_ch]
+
+        ok, msg = rabbit.check_health(check_consumers=True)
+
+        self.assertFalse(ok)
+        self.assertEqual(msg, "No consumers available")
+
+
+class TestSendThreadSafety(TestCase):
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_send_uses_publish_lock(self, mock_uri_conn):
+        rabbit = _make_rabbit()
+        conn = _make_mock_connection()
+        mock_uri_conn.return_value = conn
+        rabbit.json_encoder = None
+        rabbit.development = False
+
+        publish_channel = conn.channel.return_value
+        rabbit.connection = conn
+        rabbit.channel = publish_channel
+
+        rabbit.send({"test": "data"}, routing_key="test.route")
+
+        publish_channel.basic.publish.assert_called_once()
+        # Verify the publish channel (self.channel) is used, not a consumer channel
+        self.assertEqual(rabbit.channel, publish_channel)
+
+
 class TestStop(TestCase):
-    def test_stop_closes_connection(self):
-        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
-            from amqpstorm_flask.RabbitMQ import RabbitMQ
-            rabbit = RabbitMQ.__new__(RabbitMQ)
-            rabbit.connection = MagicMock()
-            rabbit.connection.is_closed = False
-            rabbit.channel = MagicMock()
-            rabbit.logger = MagicMock()
-            rabbit._reconnect_lock = threading.Lock()
-            rabbit.scheduler = MagicMock()
+    def test_stop_closes_connection_and_channels(self):
+        rabbit = _make_rabbit()
+        conn = MagicMock(is_closed=False)
+        rabbit.connection = conn
+        rabbit.channel = MagicMock(is_closed=False)
+        ch1 = MagicMock(is_closed=False)
+        rabbit._consumer_channels = [ch1]
 
-            rabbit.stop()
+        rabbit.stop()
 
-            rabbit.connection_ref = rabbit.connection
-            rabbit.scheduler.shutdown.assert_called_once()
+        rabbit.scheduler.shutdown.assert_called_once()
+        conn.close.assert_called_once()
+        ch1.close.assert_called_once()
+        self.assertIsNone(rabbit.connection)
+        self.assertIsNone(rabbit.channel)
+        self.assertEqual(rabbit._consumer_channels, [])
 
     def test_stop_with_no_connection(self):
-        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
-            from amqpstorm_flask.RabbitMQ import RabbitMQ
-            rabbit = RabbitMQ.__new__(RabbitMQ)
-            rabbit.connection = None
-            rabbit.channel = None
-            rabbit.logger = MagicMock()
-            rabbit._reconnect_lock = threading.Lock()
-            rabbit.scheduler = MagicMock()
+        rabbit = _make_rabbit()
 
-            rabbit.stop()
+        rabbit.stop()
 
-            rabbit.scheduler.shutdown.assert_called_once()
-            self.assertIsNone(rabbit.connection)
+        rabbit.scheduler.shutdown.assert_called_once()
+        self.assertIsNone(rabbit.connection)

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,0 +1,286 @@
+import threading
+import time
+from unittest import TestCase
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+class TestCloseConnection(TestCase):
+    def _make_rabbit(self):
+        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
+            from amqpstorm_flask.RabbitMQ import RabbitMQ
+            rabbit = RabbitMQ.__new__(RabbitMQ)
+            rabbit.connection = None
+            rabbit.channel = None
+            rabbit.mq_url = "amqp://localhost"
+            rabbit.mq_exchange = "test"
+            rabbit.logger = MagicMock()
+            rabbit.last_message_consumed_at = 0
+            rabbit._reconnect_lock = threading.Lock()
+            rabbit.scheduler = MagicMock()
+            rabbit.exchange_params = MagicMock()
+            rabbit.queue_params = MagicMock()
+        return rabbit
+
+    def test_close_connection_when_open(self):
+        rabbit = self._make_rabbit()
+        mock_conn = MagicMock()
+        mock_conn.is_closed = False
+        rabbit.connection = mock_conn
+
+        rabbit._close_connection()
+
+        mock_conn.close.assert_called_once()
+        self.assertIsNone(rabbit.connection)
+        self.assertIsNone(rabbit.channel)
+
+    def test_close_connection_when_already_closed(self):
+        rabbit = self._make_rabbit()
+        mock_conn = MagicMock()
+        mock_conn.is_closed = True
+        rabbit.connection = mock_conn
+
+        rabbit._close_connection()
+
+        mock_conn.close.assert_not_called()
+        self.assertIsNone(rabbit.connection)
+
+    def test_close_connection_when_none(self):
+        rabbit = self._make_rabbit()
+        rabbit.connection = None
+
+        rabbit._close_connection()
+
+        self.assertIsNone(rabbit.connection)
+        self.assertIsNone(rabbit.channel)
+
+    def test_close_connection_handles_close_exception(self):
+        rabbit = self._make_rabbit()
+        mock_conn = MagicMock()
+        mock_conn.is_closed = False
+        mock_conn.close.side_effect = Exception("socket error")
+        rabbit.connection = mock_conn
+
+        rabbit._close_connection()
+
+        self.assertIsNone(rabbit.connection)
+        self.assertIsNone(rabbit.channel)
+
+
+class TestValidateChannelConnection(TestCase):
+    def _make_rabbit(self):
+        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
+            from amqpstorm_flask.RabbitMQ import RabbitMQ
+            rabbit = RabbitMQ.__new__(RabbitMQ)
+            rabbit.connection = None
+            rabbit.channel = None
+            rabbit.mq_url = "amqp://localhost"
+            rabbit.mq_exchange = "test"
+            rabbit.logger = MagicMock()
+            rabbit.last_message_consumed_at = 0
+            rabbit._reconnect_lock = threading.Lock()
+            rabbit.scheduler = MagicMock()
+            rabbit.exchange_params = MagicMock()
+            rabbit.queue_params = MagicMock()
+        return rabbit
+
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_validate_handles_none_channel(self, mock_uri_conn):
+        rabbit = self._make_rabbit()
+        rabbit.connection = None
+        rabbit.channel = None
+
+        mock_conn = MagicMock()
+        mock_conn.is_closed = False
+        mock_channel = MagicMock()
+        mock_channel.is_closed = False
+        mock_conn.channel.return_value = mock_channel
+        mock_uri_conn.return_value = mock_conn
+
+        rabbit._validate_channel_connection()
+
+        mock_uri_conn.assert_called_once_with("amqp://localhost")
+        self.assertEqual(rabbit.connection, mock_conn)
+        self.assertEqual(rabbit.channel, mock_channel)
+
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_validate_closes_old_connection(self, mock_uri_conn):
+        rabbit = self._make_rabbit()
+
+        old_conn = MagicMock()
+        old_conn.is_closed = False
+        rabbit.connection = old_conn
+        rabbit.channel = MagicMock()
+        rabbit.channel.is_closed = False
+
+        rabbit.last_message_consumed_at = -1
+
+        new_conn = MagicMock()
+        new_conn.is_closed = False
+        new_channel = MagicMock()
+        new_channel.is_closed = False
+        new_conn.channel.return_value = new_channel
+        mock_uri_conn.return_value = new_conn
+
+        rabbit._validate_channel_connection()
+
+        old_conn.close.assert_called_once()
+        self.assertEqual(rabbit.connection, new_conn)
+        self.assertEqual(rabbit.channel, new_channel)
+
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_validate_skips_when_healthy(self, mock_uri_conn):
+        rabbit = self._make_rabbit()
+
+        mock_conn = MagicMock()
+        mock_conn.is_closed = False
+        mock_channel = MagicMock()
+        mock_channel.is_closed = False
+        rabbit.connection = mock_conn
+        rabbit.channel = mock_channel
+        rabbit.last_message_consumed_at = 0
+
+        rabbit._validate_channel_connection()
+
+        mock_uri_conn.assert_not_called()
+
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_validate_lock_prevents_concurrent_reconnection(self, mock_uri_conn):
+        rabbit = self._make_rabbit()
+        rabbit.connection = None
+        rabbit.channel = None
+
+        call_count = 0
+        barrier = threading.Barrier(2, timeout=5)
+
+        original_uri = mock_uri_conn
+
+        def slow_connect(url):
+            nonlocal call_count
+            call_count += 1
+            barrier.wait()
+            time.sleep(0.1)
+            conn = MagicMock()
+            conn.is_closed = False
+            channel = MagicMock()
+            channel.is_closed = False
+            conn.channel.return_value = channel
+            return conn
+
+        mock_uri_conn.side_effect = slow_connect
+
+        t1 = threading.Thread(target=rabbit._validate_channel_connection)
+        t2 = threading.Thread(target=rabbit._validate_channel_connection)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        self.assertEqual(call_count, 1)
+
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_validate_logs_error_on_connection_failure(self, mock_uri_conn):
+        rabbit = self._make_rabbit()
+        rabbit.connection = None
+        rabbit.channel = None
+
+        mock_uri_conn.side_effect = Exception("Connection refused")
+
+        rabbit._validate_channel_connection()
+
+        rabbit.logger.error.assert_called_once()
+        self.assertIn("Connection refused", rabbit.logger.error.call_args[0][0])
+
+
+class TestNewConsumerNoRecursion(TestCase):
+    @patch("amqpstorm_flask.RabbitMQ.sleep")
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    @patch.dict("os.environ", {
+        "AMQP_STORM_APSCHEDULER": "0",
+        "WERKZEUG_RUN_MAIN": "true",
+        "MQ_URL": "amqp://localhost",
+        "MQ_EXCHANGE": "test",
+    })
+    def test_consumer_retries_without_stack_overflow(self, mock_uri_conn, mock_sleep):
+        from amqpstorm_flask.RabbitMQ import RabbitMQ
+
+        attempt = 0
+        max_failures = 5
+        done_event = threading.Event()
+
+        def side_effect(url):
+            nonlocal attempt
+            attempt += 1
+            if attempt <= max_failures:
+                raise Exception(f"Failure {attempt}")
+            conn = MagicMock()
+            conn.is_closed = False
+            channel = MagicMock()
+            channel.is_closed = False
+
+            def stop_consuming():
+                done_event.set()
+                raise Exception("done")
+            channel.start_consuming.side_effect = stop_consuming
+            conn.channel.return_value = channel
+            return conn
+
+        mock_uri_conn.side_effect = side_effect
+
+        rabbit = RabbitMQ.__new__(RabbitMQ)
+        rabbit.connection = None
+        rabbit.channel = None
+        rabbit.mq_url = "amqp://localhost"
+        rabbit.mq_exchange = "test"
+        rabbit.logger = MagicMock()
+        rabbit.last_message_consumed_at = 0
+        rabbit._reconnect_lock = threading.Lock()
+        rabbit.scheduler = MagicMock()
+        rabbit.exchange_params = MagicMock()
+        rabbit.queue_params = MagicMock()
+        rabbit.queue_params.no_ack = True
+        rabbit.queue_params.durable = True
+        rabbit.queue_params.passive = False
+        rabbit.queue_params.auto_delete = False
+        rabbit.json_encoder = None
+        rabbit.development = False
+
+        @rabbit.queue(routing_key="test.key", queue_name="test-queue")
+        def test_handler(routing_key, body, message_id):
+            pass
+
+        done_event.wait(timeout=10)
+        self.assertTrue(done_event.is_set())
+        self.assertGreater(attempt, max_failures)
+
+
+class TestStop(TestCase):
+    def test_stop_closes_connection(self):
+        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
+            from amqpstorm_flask.RabbitMQ import RabbitMQ
+            rabbit = RabbitMQ.__new__(RabbitMQ)
+            rabbit.connection = MagicMock()
+            rabbit.connection.is_closed = False
+            rabbit.channel = MagicMock()
+            rabbit.logger = MagicMock()
+            rabbit._reconnect_lock = threading.Lock()
+            rabbit.scheduler = MagicMock()
+
+            rabbit.stop()
+
+            rabbit.connection_ref = rabbit.connection
+            rabbit.scheduler.shutdown.assert_called_once()
+
+    def test_stop_with_no_connection(self):
+        with patch.dict("os.environ", {"MQ_URL": "amqp://localhost", "MQ_EXCHANGE": "test"}):
+            from amqpstorm_flask.RabbitMQ import RabbitMQ
+            rabbit = RabbitMQ.__new__(RabbitMQ)
+            rabbit.connection = None
+            rabbit.channel = None
+            rabbit.logger = MagicMock()
+            rabbit._reconnect_lock = threading.Lock()
+            rabbit.scheduler = MagicMock()
+
+            rabbit.stop()
+
+            rabbit.scheduler.shutdown.assert_called_once()
+            self.assertIsNone(rabbit.connection)

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -16,7 +16,9 @@ def _make_rabbit():
         rabbit.last_message_consumed_at = 0
         rabbit._reconnect_lock = threading.Lock()
         rabbit._publish_lock = threading.Lock()
+        rabbit._consumer_channels_lock = threading.Lock()
         rabbit._consumer_channels = []
+        rabbit._exchange_declared = set()
         rabbit.scheduler = MagicMock()
         rabbit.exchange_params = MagicMock()
         rabbit.queue_params = MagicMock()
@@ -233,7 +235,9 @@ class TestPerConsumerChannels(TestCase):
         rabbit.last_message_consumed_at = 0
         rabbit._reconnect_lock = threading.Lock()
         rabbit._publish_lock = threading.Lock()
+        rabbit._consumer_channels_lock = threading.Lock()
         rabbit._consumer_channels = []
+        rabbit._exchange_declared = set()
         rabbit.scheduler = MagicMock()
         rabbit.exchange_params = MagicMock()
         rabbit.queue_params = MagicMock()
@@ -312,7 +316,9 @@ class TestNewConsumerNoRecursion(TestCase):
         rabbit.last_message_consumed_at = 0
         rabbit._reconnect_lock = threading.Lock()
         rabbit._publish_lock = threading.Lock()
+        rabbit._consumer_channels_lock = threading.Lock()
         rabbit._consumer_channels = []
+        rabbit._exchange_declared = set()
         rabbit.scheduler = MagicMock()
         rabbit.exchange_params = MagicMock()
         rabbit.queue_params = MagicMock()
@@ -404,8 +410,53 @@ class TestSendThreadSafety(TestCase):
         self.assertEqual(rabbit.channel, publish_channel)
 
 
+class TestExchangeCache(TestCase):
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_exchange_declared_once_per_connection(self, mock_uri_conn):
+        rabbit = _make_rabbit()
+        conn = _make_mock_connection()
+        mock_uri_conn.return_value = conn
+        rabbit.connection = conn
+        rabbit.channel = conn.channel.return_value
+        rabbit.json_encoder = None
+        rabbit.development = False
+
+        rabbit.send({"msg": 1}, routing_key="test.route")
+        rabbit.send({"msg": 2}, routing_key="test.route")
+
+        # exchange.declare called only once despite two sends
+        self.assertEqual(rabbit.channel.exchange.declare.call_count, 1)
+
+    @patch("amqpstorm_flask.RabbitMQ.UriConnection")
+    def test_exchange_cache_cleared_on_reconnect(self, mock_uri_conn):
+        rabbit = _make_rabbit()
+        rabbit._exchange_declared.add("test-exchange")
+
+        conn = _make_mock_connection()
+        mock_uri_conn.return_value = conn
+
+        rabbit._close_connection()
+
+        self.assertEqual(rabbit._exchange_declared, set())
+
+
+class TestHealthCheckCleanup(TestCase):
+    def test_health_check_removes_dead_channels(self):
+        rabbit = _make_rabbit()
+        rabbit.connection = _make_mock_connection()
+        dead_ch = MagicMock(is_closed=True, consumer_tags=["old"])
+        alive_ch = MagicMock(is_closed=False, consumer_tags=["active"])
+        rabbit._consumer_channels = [dead_ch, alive_ch]
+
+        ok, msg = rabbit.check_health(check_consumers=True)
+
+        self.assertTrue(ok)
+        self.assertEqual(len(rabbit._consumer_channels), 1)
+        self.assertIs(rabbit._consumer_channels[0], alive_ch)
+
+
 class TestStop(TestCase):
-    def test_stop_closes_connection_and_channels(self):
+    def test_stop_stops_consuming_then_closes(self):
         rabbit = _make_rabbit()
         conn = MagicMock(is_closed=False)
         rabbit.connection = conn
@@ -416,11 +467,24 @@ class TestStop(TestCase):
         rabbit.stop()
 
         rabbit.scheduler.shutdown.assert_called_once()
+        ch1.stop_consuming.assert_called_once()
         conn.close.assert_called_once()
-        ch1.close.assert_called_once()
         self.assertIsNone(rabbit.connection)
         self.assertIsNone(rabbit.channel)
         self.assertEqual(rabbit._consumer_channels, [])
+
+    def test_stop_handles_stop_consuming_error(self):
+        rabbit = _make_rabbit()
+        rabbit.connection = MagicMock(is_closed=False)
+        rabbit.channel = MagicMock(is_closed=False)
+        ch1 = MagicMock(is_closed=False)
+        ch1.stop_consuming.side_effect = Exception("not consuming")
+        rabbit._consumer_channels = [ch1]
+
+        rabbit.stop()
+
+        rabbit.scheduler.shutdown.assert_called_once()
+        self.assertIsNone(rabbit.connection)
 
     def test_stop_with_no_connection(self):
         rabbit = _make_rabbit()


### PR DESCRIPTION
This branch fixes critical connection management bugs in amqpstorm-flask that caused a production incident where a service accumulated 2000+ zombie RabbitMQ connections and hit the memory high-water mark.

  ### Commit 1: Fix connection leak and reconnection logic

  **Connection leak** — `_validate_channel_connection()` created a new `UriConnection` without closing the old one. Each leaked connection keeps 2+ background threads (IO + heartbeat) and a TCP socket alive indefinitely. Now calls `_close_connection()`
  before reconnecting.

  **NoneType crash** — `self.channel.is_closed` would raise `AttributeError` when `self.channel` was `None` (e.g. on first call). Added proper `None` guard.

  **Unbounded recursion** — Both `_validate_channel_connection()` and `new_consumer()` called themselves recursively without a depth limit, hitting Python's recursion limit (~1000) after ~17 minutes of persistent failure. Replaced with iterative `while
  True` loop with exponential backoff (1s up to 60s).

  **Concurrent reconnection** — Multiple threads (APScheduler + consumers) could call `_validate_channel_connection()` simultaneously, each creating a new connection. Added a `threading.Lock` with non-blocking acquire so only one thread reconnects at a
  time.

  **`except BaseException` preventing graceful shutdown** — `BaseException` catches `SystemExit` and `KeyboardInterrupt`, so `Ctrl+C` or a graceful shutdown would be swallowed and the consumer would restart instead of stopping. Changed to `except
  Exception`.

  **Unused `import sys`** removed.

  **`stop()` now closes the connection** for proper resource cleanup.

  ### Commit 2: Per-consumer channels for thread safety

  The original code used a single shared `self.channel` for all consumers and publishing. This is fundamentally not thread-safe — one thread could replace the channel while another was consuming on it.

  Each consumer now creates its own dedicated channel on the shared connection. This is how AMQP is designed: one TCP connection, multiple channels. `self.channel` is now the dedicated publish channel, protected by a `_publish_lock` to serialize
  concurrent `send()` calls.

  `check_health()` updated to check the `_consumer_channels` list instead of the shared channel's consumer tags. `_close_connection()` properly closes all consumer channels, the publish channel, and the connection.

  ### Commit 3: Polish thread safety and resource management

  **Removed `filterwarnings("ignore", "unclosed", ResourceWarning)`** — This was hiding warnings about leaked sockets. Now that connections are properly closed, these warnings would indicate real issues.

  **Graceful consumer shutdown** — `stop()` calls `stop_consuming()` on each consumer channel before closing connections, allowing in-flight messages to complete.

  **Thread-safe consumer channel tracking** — `_consumer_channels` list access is now protected by `_consumer_channels_lock`.

  **Exchange declaration cache** — `exchange.declare()` was called on every `send()`, adding an unnecessary RPC round-trip. Now cached per connection in `_exchange_declared` set, cleared on reconnect.

  **Dead channel cleanup** — `check_health()` now prunes closed channels from the `_consumer_channels` list.

  **Configurable max backoff** — Via `MQ_MAX_CONSUMER_BACKOFF` env var (default: 60s).

  ### Tests

  Added 26 unit tests (the library previously had none) covering connection lifecycle, reconnection logic, thread safety, per-consumer channels, health checks, exchange caching, and graceful shutdown. All tests use `unittest.mock` — no RabbitMQ server
  required.

  ### Backwards compatibility

  All public method signatures are unchanged. Existing services work without configuration changes.
